### PR TITLE
fix(ci): Use client environment variables during Docker build

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -42,6 +42,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
+      - name: Echo environment variables to .env.local
+        run: |
+          echo "NEXT_PUBLIC_UMAMI_WEBSITE_ID=${{ secrets.NEXT_PUBLIC_UMAMI_WEBSITE_ID }}" >> .env.local
+          echo "NEXT_PUBLIC_FEEDBACK_FORM_URL=${{ secrets.NEXT_PUBLIC_FEEDBACK_FORM_URL }}" >> .env.local
+
       - name: Build Docker container
         env:
           PRODUCTION_BUILD: 'true'


### PR DESCRIPTION
### Description
Use client environment variables during Docker build.

### Changes Made
Use client environment variables during Docker build.

### Related Issues
N/A

### Additional Notes
N/A
